### PR TITLE
✨ Abstract Out Version Logic Into Library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ vendor/
 
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-# composer.lock
+composer.lock

--- a/bin/bump
+++ b/bin/bump
@@ -1,69 +1,31 @@
 #! /usr/bin/php
 <?php
 
-$major = 0;
-$minor = 0;
-$patch = 0;
-
 if (empty($argv[1]) || !in_array($argv[1], ['major', 'minor', 'patch'])) {
-	echo 'Please supply a bump type: major, minor, patch.' . PHP_EOL;
-	exit;
+    echo 'Please supply a bump type: major, minor, patch.' . PHP_EOL;
+    exit;
 }
 
 $bump = $argv[1];
 
-$tags = explode(PHP_EOL, shell_exec('git tag'));
-foreach ($tags as $tag) {
-	$parts = explode('.', $tag);
-	if (count($parts) !== 3) {
-		continue;
-	}
+$comparison = new \Bump\Compare(function ($tag) {
+    return new \Bump\Version\SemVer($tag);
+});
 
-	if ($parts[0] > $major) {
-		$major = $parts[0];
-		$minor = $parts[1];
-		$patch = $parts[2];
-	} elseif ($parts[0] == $major) {
-		if ($parts[1] > $minor) {
-			$minor = $parts[1];
-			$patch = $parts[2];
-		} elseif ($parts[1] == $minor && $parts[2] > $patch) {
-			$patch = $parts[2];
-		}
-	}
-}
+$current_tag = $comparison->getLatestTag(explode(PHP_EOL, shell_exec('git tag')));
+$next_tag = $current_tag->bump($bump);
 
-$current_version = implode('.', [$major, $minor, $patch]);
 
-switch ($bump) {
-	case 'major':
-		$major++;
-		$minor = 0;
-		$patch = 0;
-		break;
-
-	case 'minor':
-		$minor++;
-		$patch = 0;
-		break;
-
-	case 'patch':
-		$patch++;
-		break;
-}
-
-$bumped_version = implode('.', [$major, $minor, $patch]);
-
-$cmd = 'git shortlog ' . $current_version . '..';
-echo PHP_EOL . 'git shortlog ' . $current_version . '..' . PHP_EOL;
+$cmd = 'git shortlog ' . $current_tag->formatTag() . '..';
+echo PHP_EOL . 'git shortlog ' . $current_tag->formatTag() . '..' . PHP_EOL;
 passthru($cmd);
 
-$tagit = readline('Do you want to create and push a new tag (' . $bumped_version . ') with the above changes? (y/n):');
+$tagit = readline('Do you want to create and push a new tag (' . $next_tag->formatTag() . ') with the above changes? (y/n):');
 if (strtolower($tagit) !== 'y') {
-	echo 'It\'s cool. I understand.' . PHP_EOL;
-	exit;
+    echo 'It\'s cool. I understand.' . PHP_EOL;
+    exit;
 }
 
-passthru('git tag ' . $bumped_version);
-passthru('git push origin ' . $bumped_version);
+passthru('git tag ' . $next_tag->formatTag());
+passthru('git push origin ' . $next_tag->formatTag());
 echo $bumped_version . ' has been tagged.' . PHP_EOL;

--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,11 @@
         }
     ],
     "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "4.8.*"
+    },
+    "autoload": {
+        "psr-4": { "Bump\\": "src/" }
+    },
     "bin": ["bin/bump"]
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Package Test Suite">
+            <directory suffix=".php">test/unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Compare.php
+++ b/src/Compare.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Bump;
+
+class Compare
+{
+    /** @var callable */
+    private $tag_factory;
+
+    public function __construct(callable $tag_factory)
+    {
+        $this->tag_factory = $tag_factory;
+    }
+
+    /**
+     * @param string[] $repository_tags The list of tags from your source code repository.
+     * @param string   $starting_tag    The earliest possible tag for your tagging system, 0.0.0 for SemVer.
+     *
+     * @return Version The current tag.
+     */
+    public function getLatestTag(array $repository_tags, $starting_tag = '0.0.0')
+    {
+        $current = call_user_func($this->tag_factory, $starting_tag);
+        foreach ($repository_tags as $repository_tag) {
+            /** @var Version $tag */
+            $tag = call_user_func($this->tag_factory, $repository_tag);
+
+            if ($tag->exclude()) {
+                continue;
+            }
+
+            if ($current->compare($tag) === Version::LESSER) {
+                $current = $tag;
+            }
+        }
+
+        return $current;
+    }
+}

--- a/src/Version.php
+++ b/src/Version.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Bump;
+
+interface Version
+{
+    const EQUAL = 0;
+    const LESSER = -1;
+    const GREATER = 1;
+
+    /**
+     * Determine if the tag should be included in the set of computed tags.
+     *
+     * Check's to make sure that the tag conforms to whatever tagging format you we specify.
+     *
+     * @return bool
+     */
+    public function exclude();
+
+    /**
+     * @param string $touple The portion of the tag to bump, for sem ver should be major, minor, or patch
+     *
+     * @return Self A new instance of Version with the correctly bumped touple
+     */
+    public function bump($touple);
+
+    /**
+     * Compares the version against another version.
+     *
+     * @param Version $version
+     *
+     * @return int -1 When the instance version is lower than the parameter version, 0 when they're equal, and 1
+     *             when the instance version is greater than the parameter version.
+     */
+    public function compare(Version $version);
+
+    /**
+     * @return string THe human readable version of the tag.
+     */
+    public function getTag();
+}

--- a/src/Version/SemVer.php
+++ b/src/Version/SemVer.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Bump\Version;
+
+use Bump\Version;
+
+class SemVer implements Version
+{
+    /** @var string The major version */
+    private $major;
+
+    /** @var string The minor version */
+    private $minor;
+
+    /** @var string The patch version */
+    private $patch;
+
+    /** @var bool Determine if the tag is in a valid format. */
+    private $is_valid_format = false;
+
+    public function __construct($tag)
+    {
+        if ($this->init($tag)) {
+            $this->is_valid_format = true;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function exclude()
+    {
+        return !$this->is_valid_format;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function bump($touple)
+    {
+        $touple_map = [
+            'patch' => 'bumpPatch',
+            'minor' => 'bumpMinor',
+            'major' => 'bumpMajor'
+        ];
+
+        if (!isset($touple_map[$touple])) {
+            throw new \InvalidArgumentException($touple . ' is not an allowed touple');
+        }
+
+        return $this->{$touple_map[$touple]}();
+    }
+
+    /**
+     * Generates the patch bump for the given tag.
+     *
+     * @return self
+     */
+    protected function bumpPatch()
+    {
+        $version = clone $this;
+        $version->patch++;
+        return $version;
+    }
+
+    /**
+     * Generates the minor bump for the given tag.
+     *
+     * @return string
+     */
+    protected function bumpMinor()
+    {
+        $version = clone $this;
+        $version->minor++;
+        $version->patch = 0;
+        return $version;
+    }
+
+    /**
+     * Generates the major bump for the given tag.
+     *
+     * @return string
+     */
+    protected function bumpMajor()
+    {
+        $version = clone $this;
+        $version->major++;
+        $version->patch = 0;
+        $version->minor = 0;
+        return $version;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getTag()
+    {
+        return sprintf('%d.%d.%d', $this->major, $this->minor, $this->patch);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function compare(Version $version)
+    {
+        $major = $this->spaceShip($this->major, $version->major);
+        if ($major !== VERSION::EQUAL) {
+            return $major;
+        }
+
+        $minor = $this->spaceShip($this->minor, $version->minor);
+        if ($minor !== Version::EQUAL) {
+            return $minor;
+        }
+
+        return $this->spaceShip($this->patch, $version->patch);
+    }
+
+    /**
+     * Initializes the major, minor, and patch properties.
+     *
+     * @param string $tag
+     *
+     * @return bool True if the raw_tag is formatted correctly, false if the format is incorrect.
+     */
+    protected function init($tag)
+    {
+        $parts = explode('.', $tag);
+
+        if (count($parts) !== 3) {
+            return false;
+        }
+
+        list($this->major, $this->minor, $this->patch) = $parts;
+
+        return true;
+    }
+
+    /**
+     * Performs the same action as `<=>` operation in php 7.
+     *
+     * @param string|int $instance
+     * @param string|int $parameter
+     *
+     * @return int -1 when instance is less than parameter, 0 if they're equal and 1 if instance is greater than
+     *              parameter.
+     */
+    private function spaceShip($instance, $parameter)
+    {
+        if ($instance == $parameter) {
+            return 0;
+        }
+
+        return $instance > $parameter ? 1 : -1;
+    }
+}

--- a/tests/unit/CompareTest.php
+++ b/tests/unit/CompareTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Bump;
+
+use Bump\Version\SemVer;
+use PHPUnit_Framework_TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+class CompareTest extends PHPUnit_Framework_TestCase
+{
+    /** @var Compare */
+    private $compare;
+
+    /** @var TagFactory|MockObject */
+    private $tag_factory;
+
+    public function setUp()
+    {
+        $this->tag_factory = $this->getMock(TagFactory::class);
+        $this->compare = new Compare($this->tag_factory);
+    }
+
+    public function testWithNoTagsReturnsTheCurrentVersion()
+    {
+        $expected = $this->getMock(Version::class);
+        $this->tag_factory->expects($this->once())
+            ->method('__invoke')
+            ->with('0.0.0')
+            ->willReturn($expected);
+
+        $this->assertSame($expected, $this->compare->getLatestTag([]));
+    }
+
+    public function testExcludedTagsAreNotIncludedInComparison()
+    {
+        $base_tag = $this->getMock(Version::class);
+        $excluded_tag = $this->getMock(Version::class);
+
+        $this->tag_factory->expects($this->exactly(2))
+            ->method('__invoke')
+            ->withConsecutive(['0.0.0'], ['irregular-tag'])
+            ->willReturnOnConsecutiveCalls($base_tag, $excluded_tag);
+
+        $base_tag->expects($this->never())->method('compare');
+        $excluded_tag->expects($this->once())
+            ->method('exclude')
+            ->willReturn(true);
+
+        $this->assertSame($base_tag, $this->compare->getLatestTag(['irregular-tag']));
+    }
+
+    public function testCompare()
+    {
+        $base_tag = $this->getMock(Version::class);
+        $lower_tag = $this->getMock(Version::class);
+        $upper_tag = $this->getMock(Version::class);
+
+
+        $this->tag_factory->expects($this->exactly(3))
+            ->method('__invoke')
+            ->withConsecutive(['0.0.0'], ['1.0.1'], ['1.0.2'])
+            ->willReturnOnConsecutiveCalls($base_tag, $lower_tag, $upper_tag);
+
+        $base_tag->expects($this->once())
+            ->method('compare')
+            ->with($lower_tag)
+            ->willReturn(-1);
+
+        $lower_tag->expects($this->once())
+            ->method('compare')
+            ->with($upper_tag)
+            ->willReturn(-1);
+
+        $this->assertSame($upper_tag, $this->compare->getLatestTag(['1.0.1', '1.0.2']));
+    }
+}
+
+class TagFactory
+{
+    public function __invoke($tag) {}
+}

--- a/tests/unit/Version/SemVerTest.php
+++ b/tests/unit/Version/SemVerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Bump\Version;
+
+use Bump\Version;
+use PHPUnit_Framework_TestCase;
+
+class SemVerTest extends PHPUnit_Framework_TestCase
+{
+    public function testValuesThatDoNotMatchSemVerFormatThrowException()
+    {
+        $version = new SemVer('hello.world');
+        $this->assertTrue($version->exclude());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testBumpThrowsAnExceptionWhenSuppliedInvalidTouple()
+    {
+        $version = new SemVer('1.0.1');
+        $version->bump('your-face');
+    }
+
+    /**
+     * @param string $touple           The touple to bump, can either be patch, minor, or major
+     * @param string $starting_version The starting version
+     * @param string $expected_version The expected final version
+     *
+     * @dataProvider bumpDataProvider
+     */
+    public function testBumpIncreasesTouplesCorrectly($touple, $starting_version, $expected_version)
+    {
+        $expected = new SemVer($expected_version);
+        $starting = new SemVer($starting_version);
+
+        $this->assertEquals($expected, $starting->bump($touple));
+    }
+
+    public function bumpDataProvider()
+    {
+        return [
+            'patch' => ['patch', '1.5.1', '1.5.2'],
+            'minor' => ['minor', '1.5.2', '1.6.0'],
+            'major' => ['major', '1.5.2', '2.0.0'],
+        ];
+    }
+
+    public function testGetTag()
+    {
+        $version = new SemVer('123.456.789');
+        $this->assertEquals('123.456.789', $version->getTag());
+    }
+
+    /**
+     * @param Semver $instance   The object compare is being called on
+     * @param Semver $comparator The object being passed into the comparison
+     * @param int    $expected   either 1, 0, or -1
+     *
+     * @dataProvider comparisonDataProvider
+     */
+    public function testCompare(Semver $instance, Semver $comparator, $expected)
+    {
+        $this->assertEquals($expected, $instance->compare($comparator));
+    }
+
+    public function comparisonDataProvider()
+    {
+        return [
+            'Major Less Than'    => [new SemVer('0.1.1'), new SemVer('1.0.0'), Version::LESSER],
+            'Major Greater Than' => [new SemVer('2.1.1'), new SemVer('1.0.0'), Version::GREATER],
+
+            'Minor Less Than'    => [new SemVer('0.1.1'), new SemVer('0.2.0'), Version::LESSER],
+            'Minor Greater Than' => [new SemVer('2.1.1'), new SemVer('2.0.0'), Version::GREATER],
+
+            'Patch Less Than'    => [new SemVer('0.0.1'), new SemVer('0.0.3'), Version::LESSER],
+            'Patch Greater Than' => [new SemVer('2.1.1'), new SemVer('2.1.0'), Version::GREATER],
+
+            'Patch Greater Than' => [new SemVer('2.1.1'), new SemVer('2.1.1'), Version::EQUAL],
+        ];
+    }
+}


### PR DESCRIPTION
This will allow teams that don't use SemVer to define their own Version and use
the same bump commands.

This is still in development phase(I haven't tested beyond unit tests), just curious about your feedback.